### PR TITLE
Check for null tiles to avoid crash

### DIFF
--- a/UIWorldLoadSpecial.cs
+++ b/UIWorldLoadSpecial.cs
@@ -387,7 +387,7 @@ namespace WorldGenPreviewer
 			int tileY = (int)((-num2 + (float)Main.mouseY) / Main.mapFullscreenScale + offscreenYMin);
 			if (WorldGen.InWorld(tileX, tileY, 10))
 			{
-				statusLabel.SetText("TileID: " + Main.tile[tileX, tileY].type);
+				statusLabel.SetText("TileID: " + Main.tile[tileX, tileY]?.type);
 				if (Main.mouseRight && Main.mouseRightRelease)
 				{
 					//	WorldGen.ShroomPatch(tileX, tileY);


### PR DESCRIPTION
In some cases the game will crash during WorldGen depending on your mods. I noticed this while developing TUA's Dimlibs.

This will check if tiles are null before trying to display their type.